### PR TITLE
🎨 feat : Student 및 Wechsler 모델 구현 #9

### DIFF
--- a/BACKEND/app/db/base.py
+++ b/BACKEND/app/db/base.py
@@ -15,3 +15,8 @@ class Base(DeclarativeBase):
     """
     pass
 
+
+# Import all models here to register them with Base.metadata
+from app.models.student import Student  # noqa: E402, F401
+from app.models.student_wechler import StudentWechsler  # noqa: E402, F401
+

--- a/BACKEND/app/models/student.py
+++ b/BACKEND/app/models/student.py
@@ -5,7 +5,7 @@ from datetime import date
 from typing import TYPE_CHECKING
 
 from sqlalchemy import String, Date, Integer
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
 
@@ -25,4 +25,15 @@ class Student(Base):
     cognitive_level: Mapped[int | None] = mapped_column(Integer, nullable=True)
     social_psych_level: Mapped[int | None] = mapped_column(Integer, nullable=True)
     motor_daily_level: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Relationships
+    wechsler: Mapped["StudentWechsler | None"] = relationship(
+        back_populates="student",
+        uselist=False,
+        cascade="all, delete-orphan",
+    )
+    ieps: Mapped[list["IEP"]] = relationship(
+        back_populates="student",
+        cascade="all, delete-orphan",
+    )
 

--- a/BACKEND/app/models/student.py
+++ b/BACKEND/app/models/student.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from typing import TYPE_CHECKING
+
+from sqlalchemy import String, Date, Integer
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+if TYPE_CHECKING:
+    from .iep import IEP
+    from .student_wechler import StudentWechsler
+
+
+class Student(Base):
+    __tablename__ = "students"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    birth: Mapped[date] = mapped_column(Date, nullable=False)
+    grade: Mapped[str] = mapped_column(String, nullable=False)
+    guardian_opinion: Mapped[str | None] = mapped_column(String, nullable=True)
+    cognitive_level: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    social_psych_level: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    motor_daily_level: Mapped[int | None] = mapped_column(Integer, nullable=True)
+

--- a/BACKEND/app/models/student_wechler.py
+++ b/BACKEND/app/models/student_wechler.py
@@ -4,7 +4,7 @@ import uuid
 from typing import TYPE_CHECKING
 
 from sqlalchemy import ForeignKey, Integer
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
 
@@ -23,4 +23,9 @@ class StudentWechsler(Base):
     wmi_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
     psi_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
     fsiq_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Relationships
+    student: Mapped["Student"] = relationship(
+        back_populates="wechsler",
+    )
 

--- a/BACKEND/app/models/student_wechler.py
+++ b/BACKEND/app/models/student_wechler.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Integer
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+if TYPE_CHECKING:
+    from .student import Student
+
+
+class StudentWechsler(Base):
+    __tablename__ = "student_wechsler"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    student_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("students.id"), nullable=False)
+    vci_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    visual_spatial_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    fri_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    wmi_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    psi_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    fsiq_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+


### PR DESCRIPTION
## 작업 내용
ERD에 정의된 학생(Student) 및 웩슬러 지능검사(Wechsler) 정보를 다루기 위한 SQLAlchemy ORM 모델을 추가했습니다.

### 1️⃣ Student 모델 구현 (`app/models/student.py`)
- **기본 필드**:
  - `id` (UUID): 학생 고유 식별자
  - `name` (String): 학생 이름
  - `birth` (Date): 생년월일
  - `grade` (String): 학년 정보
  - `guardian_opinion` (String, nullable): 보호자 의견
  - `cognitive_level` (Integer, nullable): 인지 수준 점수
  - `social_psych_level` (Integer, nullable): 사회·정서 수준 점수
  - `motor_daily_level` (Integer, nullable): 운동·일상생활 수준 점수

- **관계(Relationship)**:
  - `wechsler` (1:0..1): Student와 StudentWechsler 간 일대일 관계
  - `ieps` (1:N): Student와 IEP 간 일대다 관계 (향후 구현 예정)

### 2️⃣ StudentWechsler 모델 구현 (`app/models/student_wechler.py`)
- **기본 필드**:
  - `id` (UUID): 웩슬러 검사 기록 고유 식별자
  - `student_id` (UUID, ForeignKey): 학생 참조 외래키
  - `vci_score` (Integer, nullable): 언어이해 지표
  - `visual_spatial_score` (Integer, nullable): 시공간 지표
  - `fri_score` (Integer, nullable): 유동추론 지표
  - `wmi_score` (Integer, nullable): 작업기억 지표
  - `psi_score` (Integer, nullable): 처리속도 지표
  - `fsiq_score` (Integer, nullable): 전체 지능 지수

- **관계(Relationship)**:
  - `student`: StudentWechsler → Student 역참조 관계

### 3️⃣ Student ↔ StudentWechsler 1:1 관계 설정
- Student 측에서 `uselist=False` 및 `cascade="all, delete-orphan"` 설정
- StudentWechsler 측에서 `back_populates="wechsler"` 설정
- 학생 삭제 시 웩슬러 검사 정보도 함께 삭제되도록 cascade 적용

### 4️⃣ DB Base에 모델 등록 (`app/db/base.py`)
- `Base.metadata`에 모델이 자동 등록되도록 import 추가:
  ```python
  from app.models.student import Student
  from app.models.student_wechler import StudentWechsler
  ```

## 테스트 방법

### 1️⃣ 백엔드 디렉토리로 이동
```bash
cd term_prj/BACKEND
```

### 2️⃣ 가상환경 활성화
```bash
source .venv/bin/activate
```
또는 가상환경 없이 직접 실행:
```bash
.venv/bin/python -m uvicorn app.main:app --reload
```

### 3️⃣ 의존성 설치 확인
가상환경에 패키지가 설치되어 있는지 확인합니다:
```bash
pip list | grep -E "fastapi|uvicorn|sqlalchemy"
```

설치되지 않았다면:
```bash
pip install -r requirements.txt
```

### 4️⃣ 환경 변수 설정 (.env 파일 생성)

#### Option A: SQLite로 빠른 테스트 (권장)
프로젝트 루트에 `.env` 파일을 생성하고 아래 내용을 작성합니다:
```bash
DATABASE_URL=sqlite:///./test_db.db
```

#### Option B: PostgreSQL 사용 (Docker)
PostgreSQL을 Docker로 띄워 로컬 FastAPI와 연동하려면 아래 절차를 따르세요.

1) `.env` 파일 작성 (`.env.example` 참고)
```bash
DATABASE_URL=postgresql+psycopg2://username:password@localhost:5432/dbname
```

2) Postgres 이미지 풀(선택) 및 컨테이너 실행
```bash
docker pull postgres:16

docker run -d \
  --name tabula-postgres \
  -e POSTGRES_USER=username \
  -e POSTGRES_PASSWORD=password \
  -e POSTGRES_DB=dbname \
  -p 5432:5432 \
  -v "$(pwd)/pgdata:/var/lib/postgresql/data" \
  postgres:16
```

설명:
- `docker run -d`는 컨테이너를 백그라운드에서 실행합니다.
- `-v "$(pwd)/pgdata:/var/lib/postgresql/data"`로 마운트하면 호스트의 `pgdata/`에 Postgres 데이터(예: `PG_VERSION`, `pg_wal/`, 테이블 파일 등)가 생성되어 로컬에서 확인할 수 있습니다.

3) FastAPI(uvicorn)를 로컬에서 실행
```bash
source .venv/bin/activate

uvicorn app.main:app --reload
```

4) 애플리케이션 시작 시 테이블이 자동 생성됩니다
- `app/main.py`의 startup 이벤트에서 `Base.metadata.create_all(bind=engine)`가 호출되어 테이블이 생성됩니다.

5) 테이블 생성 확인 (로컬에 `psql`이 없으면 `docker exec` 사용)
- 컨테이너 내부에서 확인 (권장)
```bash
docker exec -it tabula-postgres psql -U username -d dbname -c "\dt"
docker exec -it tabula-postgres psql -U username -d dbname -c "\d students"
docker exec -it tabula-postgres psql -U username -d dbname -c "\d student_wechsler"
```
6) 정리 (컨테이너/데이터 제거)
```bash
# 컨테이너 중지 및 삭제
docker stop tabula-postgres
docker rm tabula-postgres

# 호스트의 데이터 디렉터리도 제거하려면(주의: 영구 삭제)
rm -rf pgdata
```


## 이슈

Closes #9